### PR TITLE
Fix volume_set silently failing on BluOS firmware by sending integer level

### DIFF
--- a/custom_components/bluesound_alt/media_player.py
+++ b/custom_components/bluesound_alt/media_player.py
@@ -1130,7 +1130,7 @@ class BluesoundPlayer(MediaPlayerEntity):
             volume = 0
         elif volume > 1:
             volume = 1
-        return await self.send_bluesound_command(f"Volume?level={float(volume) * 100}")
+        return await self.send_bluesound_command(f"Volume?level={int(volume * 100)}")
 
     async def async_mute_volume(self, mute: bool) -> None:
         """Send mute command to media player."""


### PR DESCRIPTION
## Problem

Calling `media_player.volume_set` on a `bluesound_alt` entity returns success (HTTP 200 OK) but the player's volume does not change. No error is raised and no warning appears in the log.

## Root cause

In `async_set_volume_level`, the volume is converted to float before being placed in the URL:

```python
return await self.send_bluesound_command(f"Volume?level={float(volume) * 100}")
```

This produces URLs like `http://<player>:11000/Volume?level=50.0`. The BluOS firmware accepts the request and returns HTTP 200, but silently ignores the command because `level` is expected to be an integer.

## Verification

Tested directly against a Monitor Audio IMS-4 (BluOS-based):

| URL | Result |
|---|---|
| `http://<player>:11000/Volume?level=50` | ✅ volume changes to 50 |
| `http://<player>:11000/Volume?level=50.0` | ❌ HTTP 200, no change |
| `http://<player>:11000/Volume&level=50` | ❌ HTTP 404 |

The official `bluesound` integration in Home Assistant core is unaffected because it casts to `int` before formatting.

## Fix

Cast to `int` after scaling:

```python
return await self.send_bluesound_command(f"Volume?level={int(volume * 100)}")
```

Single-line change. Behaviour is now identical to the official integration for this call.

## Testing

- `media_player.volume_set` with `volume_level: 0.3` → player reports volume 30 at `/Status`
- `media_player.volume_set` with `volume_level: 0` → player reports volume 0
- `media_player.volume_set` with `volume_level: 1` → player reports volume 100
- Tested on Monitor Audio IMS-4